### PR TITLE
Changed sy, sx to sx, sy

### DIFF
--- a/shapedata/base_data_processing.py
+++ b/shapedata/base_data_processing.py
@@ -1038,6 +1038,7 @@ class BaseSingleImage(AbstractSingleImage):
 
         """
         scale = np.asarray(target_shape) / np.asarray(self.img.shape[:-1])
+        scale = np.array([scale[1], scale[0]])
 
         return self.transform(scale=scale, output_shape=target_shape, **kwargs)
 


### PR DESCRIPTION
Changed sy, sx to sx, sy because the AffineTrafo expects different sorted coordinates.